### PR TITLE
Wrapper to run all scripts

### DIFF
--- a/cis-1.10.1-cloud-key-rotation-period.sh
+++ b/cis-1.10.1-cloud-key-rotation-period.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ $(gcloud services list --enabled | grep -c cloudkms) == 0 ]]; 
+then
+	echo "Cloud KMS not enabled."
+	exit 1
+fi
+
 declare LOCATIONS=$(gcloud kms locations list --format="flattened(locationId)" | grep location_id | cut -d " " -f2)
 
 for LOCATION in $LOCATIONS; do

--- a/cis-1.18.1-secrets-exposed-in-cloud-functions.sh
+++ b/cis-1.18.1-secrets-exposed-in-cloud-functions.sh
@@ -32,6 +32,12 @@ do
 done;
 
 
+if [[ $(gcloud services list --enabled | grep -c -e cloudfunctions.googleapis.com) == 0 ]]; 
+then
+	echo "Cloud Functions not enabled."
+	exit 1
+fi
+
 if [[ $PROJECT_IDS == "" ]]; then
     declare PROJECT_IDS=$(gcloud projects list --format="flattened(PROJECT_ID)" | grep project_id | cut -d " " -f 2);
 fi;

--- a/cis-1.9.1-vulnerable-cloud-kms-cryptokeys.sh
+++ b/cis-1.9.1-vulnerable-cloud-kms-cryptokeys.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ $(gcloud services list --enabled | grep -c cloudkms) == 0 ]]; 
+then
+	echo "Cloud KMS not enabled."
+	exit 1
+fi
+
 declare LOCATIONS=$(gcloud kms locations list --format="flattened(locationId)" | grep location_id | cut -d " " -f2)
 
 for LOCATION in $LOCATIONS; do

--- a/cis-6.6.1-cloud-sql-public-ips.sh
+++ b/cis-6.6.1-cloud-sql-public-ips.sh
@@ -31,6 +31,11 @@ do
     esac;
 done;
 
+if [[ $(gcloud services list --enabled | grep -c sqladmin.googleapis.com) == 0 ]]; then
+	echo "Cloud SQL not enabled."
+	exit 1
+fi
+
 if [[ $PROJECT_IDS == "" ]]; then
     declare PROJECT_IDS=$(gcloud projects list --format="flattened(PROJECT_ID)" | grep project_id | cut -d " " -f 2);
 fi;

--- a/runner.sh
+++ b/runner.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+PROJECT_IDS="";
+
+print_help(){
+    echo "Usage: $0 [OPTION]..."
+    echo "Run all CIS audit scripts for each project."
+    echo "Example: $0 -p project-12345 project-54321"
+    echo 
+    echo "Options:"
+    echo "    -p, --project   projects to be audited; multiple projects are allowed; if no project provided, all projects will be audited"
+    echo "    -h, --help	    display this help and exit"
+}
+
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--help") 		set -- "$@" "-h" ;;
+    "--project")   	set -- "$@" "-p" ;;
+    *)        		set -- "$@" "$arg"
+  esac
+done
+
+while getopts "hdp:" option
+do 
+    case "${option}"
+        in
+        p)
+        	PROJECT_IDS=${OPTARG};;
+        h)
+        	print_help
+        	exit 0;;
+    esac;
+done;
+
+declare -a commands=("jq" "gcloud")
+for cmd in "${commands[@]}"; do
+    if ! command -v $cmd &> /dev/null
+    then
+        echo "$cmd could not be found on this host and is required to run the script. Please install the missing tool and try again."
+        exit 1
+    fi
+done;
+
+if [[ $PROJECT_IDS == "" ]]; then
+    declare PROJECT_IDS=$(gcloud projects list --format="flattened(PROJECT_ID)" | grep project_id | cut -d " " -f 2);
+fi;
+
+FILENAME_PATTERN="(cis)-([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2})-([a-zA-Z/-]*)"
+AUDIT_LOG_PREFIX=audit
+AUDIT_SCRIPTS=$(ls | grep -E $FILENAME_PATTERN)
+
+
+for PROJECT_ID in $PROJECT_IDS; do
+    echo "---- Starting Audit for $PROJECT_ID ----"
+    gcloud config set project $PROJECT_ID
+    AUDIT_LOG="$AUDIT_LOG_PREFIX-$PROJECT_ID.log"
+
+    for file in $AUDIT_SCRIPTS;
+    do 
+        echo "Running $file"
+        echo $file | sed -E "s/$FILENAME_PATTERN\.(sh)/------CIS \2,\3------/" >> $AUDIT_LOG
+        ./$file -p $PROJECT_ID >> $AUDIT_LOG
+        echo "-----------------------------------------" >> $AUDIT_LOG
+    done;
+done;


### PR DESCRIPTION
This request is to add a wrapper script called ``runner`` to execute all the benchmarks against a single project or multiple. The runner will also create an audit log file for each project it was run against instead of stdout.

Some of the scripts would prompt to enable when the associated cloud API was disabled so I had to add some checks to short circuit in those cases. There may be more but these were the ones I encountered.

The intent is to make this more ci/cd friendly with some output that can eventually notify on violations through a separate process. 