### PR TITLE
Additional API Enabled Checks

### DIFF
--- a/cis-1.16.1-list-organization-essential-contacts.sh
+++ b/cis-1.16.1-list-organization-essential-contacts.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+source helpers.inc
+
 declare ORGANIZATION_IDS=$(gcloud organizations list --format="flattened(ID)" | grep id | cut -d " " -f 2 | cut -d "/" -f 2)
 
 for ORGANIZATION_ID in $ORGANIZATION_IDS; do
+	if ! api_enabled essentialcontacts.googleapis.com; then
+		echo "Essential Contacts API is not enabled for Organization $ORGANIZATION_ID"
+		continue
+	fi
+
 	echo "Essential Contacts for Organization $ORGANIZATION_IDS"
 	echo ""
 	gcloud essential-contacts list --organization=$ORGANIZATION_ID;

--- a/cis-1.18.1-secrets-exposed-in-cloud-functions.sh
+++ b/cis-1.18.1-secrets-exposed-in-cloud-functions.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -41,11 +43,11 @@ for PROJECT_ID in $PROJECT_IDS; do
 
 	gcloud config set project $PROJECT_ID 2>/dev/null;
 
-	if [[ $(gcloud services list --enabled | grep -c -e cloudfunctions.googleapis.com) == 0 ]]; then
-		echo "Cloud Functions not enabled.";
+	if ! api_enabled cloudfunctions.googleapis.com; then
+		echo "Cloud Functions not enabled for Project $PROJECT_ID.";
 		continue;
-	fi;
-
+	fi
+	
 	declare RESULTS=$(gcloud functions list --quiet --format="json");
 
 	if [[ $RESULTS != "[]" ]]; then

--- a/cis-1.9.1-vulnerable-cloud-kms-cryptokeys.sh
+++ b/cis-1.9.1-vulnerable-cloud-kms-cryptokeys.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-if [[ $(gcloud services list --enabled | grep -c cloudkms) == 0 ]]; then
+ source helpers.inc
+
+if ! api_enabled cloudkms.googleapis.com; then
 	echo "Cloud KMS not enabled.";
-	exit 1;
-fi;
+	exit 1
+fi
 
 declare LOCATIONS=$(gcloud kms locations list --format="flattened(locationId)" | grep location_id | cut -d " " -f2)
 

--- a/cis-2.2.1-project-cloud-logging-sinks.sh
+++ b/cis-2.2.1-project-cloud-logging-sinks.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -36,6 +38,11 @@ if [[ $PROJECT_IDS == "" ]]; then
 fi;
 
 for PROJECT_ID in $PROJECT_IDS; do
+    if ! api_enabled logging.googleapis.com; then
+        echo "Logging API is not enabled on Project $PROJECT_ID"
+        continue
+    fi
+
     PROJECT_DETAILS=$(gcloud projects describe $PROJECT_ID --format="json");
 	PROJECT_APPLICATION=$(echo $PROJECT_DETAILS | jq -rc '.labels.app');
 	PROJECT_OWNER=$(echo $PROJECT_DETAILS | jq -rc '.labels.adid');

--- a/cis-2.2.2-folder-cloud-logging-sinks.sh
+++ b/cis-2.2.2-folder-cloud-logging-sinks.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 declare ORGANIZATIONAL_IDS=$(gcloud organizations list --format="flattened(ID)" | grep id | cut -d " " -f 2 | cut -d "/" -f 2)
 
 for ORGANIZATION_ID in $ORGANIZATIONAL_IDS; do
@@ -7,6 +9,11 @@ for ORGANIZATION_ID in $ORGANIZATIONAL_IDS; do
 	declare FOLDER_IDS=$(gcloud resource-manager folders list --organization $ORGANIZATION_ID)
 
 	for FOLDER_ID in $FOLDER_IDS; do
+    	if ! api_enabled logging.googleapis.com; then
+    	    echo "Logging API is not enabled on Folder $FOLDER_ID for Organization $ORGANIZATION_ID"
+    	    continue
+    	fi
+
 		echo "Working on Folder $FOLDER_ID"
 		echo ""
 		gcloud logging sinks list --folder=$FOLDER_ID;

--- a/cis-2.2.3-organization-cloud-logging-sinks.sh
+++ b/cis-2.2.3-organization-cloud-logging-sinks.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
+source helpers.inc
+
 declare ORGANIZATION_IDS=$(gcloud organizations list --format="flattened(ID)" | grep id | cut -d " " -f 2 | cut -d "/" -f 2)
 
 for ORGANIZATION_ID in $ORGANIZATION_IDS; do
+    if ! api_enabled logging.googleapis.com; then
+        echo "Logging API is not enabled on Organization $ORGANIZATION_ID"
+        continue
+    fi
 	echo "IAM Policy for Organization $ORGANIZATION_IDS"
 	echo ""
 	gcloud logging sinks list --organization=$ORGANIZATION_ID;

--- a/cis-3.1.1-default-networks.sh
+++ b/cis-3.1.1-default-networks.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -38,6 +40,12 @@ fi;
 
 for PROJECT_ID in $PROJECT_IDS; do
 	gcloud config set project $PROJECT_ID 2>/dev/null;
+
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
+	
 	declare RESULTS=$(gcloud compute networks list --quiet --format="json" | tr [:upper:] [:lower:] | jq '.[]');
 	
 	declare SUBNET_MODE="";

--- a/cis-3.6.1-ssh-firewall-rules.sh
+++ b/cis-3.6.1-ssh-firewall-rules.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -40,6 +42,11 @@ declare SEPARATOR="-------------------------------------------------------------
 for PROJECT_ID in $PROJECT_IDS; do
 
 	gcloud config set project $PROJECT_ID 2>/dev/null;
+
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
 
 	declare RESULTS=$(gcloud compute firewall-rules list --quiet --format="json");
 

--- a/cis-3.8.1-vpc-flow-logs.sh
+++ b/cis-3.8.1-vpc-flow-logs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -36,6 +38,10 @@ if [[ $PROJECT_IDS == "" ]]; then
 fi;
 
 for PROJECT_ID in $PROJECT_IDS; do
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
 
 	gcloud config set project $PROJECT_ID 2>/dev/null;
 

--- a/cis-3.9.1-load-balancer-tls-policy.sh
+++ b/cis-3.9.1-load-balancer-tls-policy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -41,6 +43,11 @@ for PROJECT_ID in $PROJECT_IDS; do
 
 	gcloud config set project $PROJECT_ID 2>/dev/null;
 	
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
+
 	PROJECT_DETAILS=$(gcloud projects describe $PROJECT_ID --format="json");
 	PROJECT_NAME=$(echo $PROJECT_DETAILS | jq -rc '.name');
 	PROJECT_APPLICATION=$(echo $PROJECT_DETAILS | jq -rc '.labels.app');

--- a/cis-4.1.1-compute-instance-default-service-account.sh
+++ b/cis-4.1.1-compute-instance-default-service-account.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -36,7 +38,13 @@ if [[ $PROJECT_IDS == "" ]]; then
 fi;
 
 for PROJECT_ID in $PROJECT_IDS; do	
-    PROJECT_DETAILS=$(gcloud projects describe $PROJECT_ID --format="json");
+	
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
+    
+	PROJECT_DETAILS=$(gcloud projects describe $PROJECT_ID --format="json");
 	PROJECT_APPLICATION=$(echo $PROJECT_DETAILS | jq -rc '.labels.app');
 	PROJECT_OWNER=$(echo $PROJECT_DETAILS | jq -rc '.labels.adid');
 

--- a/cis-4.3.1-project-wide-ssh-keys.sh
+++ b/cis-4.3.1-project-wide-ssh-keys.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -41,6 +43,12 @@ for PROJECT_ID in $PROJECT_IDS; do
 	PROJECT_OWNER=$(echo $PROJECT_DETAILS | jq -rc '.labels.adid');
 
 	gcloud config set project $PROJECT_ID 2>/dev/null;
+
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
+	
 	declare INSTANCES=$(gcloud compute instances list --quiet --format="json");
 
 	if [[ $INSTANCES != "[]" ]]; then

--- a/cis-4.4.1-project-level-oslogin.sh
+++ b/cis-4.4.1-project-level-oslogin.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 CSV="False";
@@ -42,13 +44,13 @@ fi;
 for PROJECT_ID in $PROJECT_IDS; do
 	gcloud config set project $PROJECT_ID 2>/dev/null;
 	sleep 0.5;
-	
-	if [[ $(gcloud services list --enabled --filter="NAME=compute.googleapis.com" | grep -c "compute.googleapis.com") == 0 ]]; then
+
+	if ! api_enabled compute.googleapis.com; then
 		if [[ $CSV != "True" ]]; then
 			echo "COMMENT: Compute Engine API is not enabled for Project $PROJECT_ID.";
 		fi;
-		continue;
-	fi;
+		continue
+	fi
 
 	declare PROJECT_INFO=$(gcloud compute project-info describe --format="json");
 

--- a/cis-4.5.1-enabled-serial-ports.sh
+++ b/cis-4.5.1-enabled-serial-ports.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -41,6 +43,12 @@ for PROJECT_ID in $PROJECT_IDS; do
 	PROJECT_OWNER=$(echo $PROJECT_DETAILS | jq -rc '.labels.adid');
 
 	gcloud config set project $PROJECT_ID 2>/dev/null;
+
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
+
 	declare INSTANCES=$(gcloud compute instances list --quiet --format="json");
 
 	if [[ $INSTANCES != "[]" ]]; then

--- a/cis-4.6.1-ip-forwarding-enabled.sh
+++ b/cis-4.6.1-ip-forwarding-enabled.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -41,6 +43,12 @@ for PROJECT_ID in $PROJECT_IDS; do
 	PROJECT_OWNER=$(echo $PROJECT_DETAILS | jq -rc '.labels.adid');
     	
 	gcloud config set project $PROJECT_ID 2>/dev/null;
+
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
+
 	declare INSTANCES=$(gcloud compute instances list --quiet --format="json");
 
 	if [[ $INSTANCES != "[]" ]]; then

--- a/cis-4.8.1-shielded-vms.sh
+++ b/cis-4.8.1-shielded-vms.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -41,6 +43,12 @@ for PROJECT_ID in $PROJECT_IDS; do
 	PROJECT_OWNER=$(echo $PROJECT_DETAILS | jq -rc '.labels.adid');
 
 	gcloud config set project $PROJECT_ID 2>/dev/null;
+
+	if ! api_enabled compute.googleapis.com; then
+		echo "Compute Engine API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
+
 	declare INSTANCES=$(gcloud compute instances list --quiet --format="json");
 
 	if [[ $INSTANCES != "[]" ]]; then

--- a/cis-4.9.1-compute-instance-public-ips.sh
+++ b/cis-4.9.1-compute-instance-public-ips.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 CSV="False";
@@ -43,7 +45,7 @@ for PROJECT_ID in $PROJECT_IDS; do
 	gcloud config set project $PROJECT_ID 2>/dev/null;
 	sleep 0.5;
 
-	if [[ $(gcloud services list --quiet --enabled --filter="NAME=compute.googleapis.com" | grep -c "compute.googleapis.com") == 0 ]]; then
+	if ! api_enabled compute.googleapis.com; then
 		if [[ $CSV != "True" ]]; then
 			echo "Compute Engine API is not enabled for Project $PROJECT_ID.";
 		fi;

--- a/cis-4.9.2-project-public-ips.sh
+++ b/cis-4.9.2-project-public-ips.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 CSV="False";
@@ -43,7 +45,7 @@ for PROJECT_ID in $PROJECT_IDS; do
 	gcloud config set project $PROJECT_ID 2>/dev/null;
 	sleep 0.5;
 	
-	if [[ $(gcloud services list --quiet --enabled --filter="NAME=compute.googleapis.com" | grep -c "compute.googleapis.com") == 0 ]]; then
+	if ! api_enabled compute.googleapis.com; then
 		if [[ $CSV != "True" ]]; then
 			echo "Compute Engine API is not enabled for Project $PROJECT_ID.";
 		fi;

--- a/cis-5.1.1-publicly-accessible-cloud-storage.sh
+++ b/cis-5.1.1-publicly-accessible-cloud-storage.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -44,6 +46,11 @@ for PROJECT_ID in $PROJECT_IDS; do
 	PROJECT_OWNER=$(echo $PROJECT_DETAILS | jq -rc '.labels.adid');	
 
 	gcloud config set project $PROJECT_ID 2>/dev/null;
+
+	if ! api_enabled storage.googleapis.com; then
+		echo "Storage API is not enabled on Project $PROJECT_ID"
+		continue
+	fi
 
 	declare BUCKETS=$(gsutil ls);
 	

--- a/cis-6.6.1-cloud-sql-public-ips.sh
+++ b/cis-6.6.1-cloud-sql-public-ips.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source helpers.inc
+
 PROJECT_IDS="";
 DEBUG="False";
 HELP=$(cat << EOL
@@ -39,8 +41,8 @@ fi;
 for PROJECT_ID in $PROJECT_IDS; do	
 	gcloud config set project $PROJECT_ID 2>/dev/null;
 
-	if [[ $(gcloud services list --enabled | grep -c sqladmin.googleapis.com) == 0 ]]; then
-		echo "Cloud SQL API not enabled.";
+	if ! api_enabled sqladmin.googleapis.com; then
+		echo "Cloud SQL API not enabled on Project $PROJECT_ID.";
 		continue;
 	fi;
 

--- a/helpers.inc
+++ b/helpers.inc
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+api_enabled(){
+    if [[ $(gcloud services list --enabled --filter="NAME=$1" | grep -c $1) -ge 1 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}


### PR DESCRIPTION
Added checks for a number of additional scripts. API's were identified with the ``--log-http`` option for each script using ``gcloud``, and the ``-DD`` option for scripts using ``gsutil``. 

Since every gcloud command calls at least one google API, I did not add checks for the common api calls such as ``cloudresourcemanager.googleapis.com`` and ``iam.googleapis.com``. In relation to these scripts, these two API's are common for commands such as ``gcloud iam`` and ``gcloud projects``. I was not able to confirm, but these do seem to be enabled by default.

Also added the include script as suggested.