### PR TITLE
adding options for help, debug, and CSV to the script, and new options -o, --owner-only for outputting only the $Owner field

### DIFF
--- a/utility-list-project-owners.sh
+++ b/utility-list-project-owners.sh
@@ -1,16 +1,56 @@
 #!/bin/bash
 
+source functions.inc
+
 declare RESULTS=$(gcloud projects list --format="json");
 
+declare DEBUG="False";
+declare CSV="False";
+declare HELP=$(cat << EOL
+	$0 [-c, --csv] [-d, --debug] [-h, --help]	
+EOL
+);
+
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--help") 	set -- "$@" "-h" ;;
+    "--debug") 	set -- "$@" "-d" ;;
+    "--csv") 	set -- "$@" "-c" ;;
+    *)        	set -- "$@" "$arg"
+  esac
+done
+
+while getopts "hdcp:" option
+do 
+    case "${option}"
+        in
+        d)
+        	DEBUG="True";;
+        c)
+        	CSV="True";;
+        h)
+        	echo $HELP; 
+        	exit 0;;
+    esac;
+done;
+
 if [[ $RESULTS != "[]" ]]; then
+	if [[ $CSV == "True" ]]; then
+		echo "\"PROJECT_NAME\",\"PROJECT_APPLICATION\",\"PROJECT_OWNER\"";
+	fi
 		
-	echo $RESULTS | jq -rc '.[]' | while IFS='' read PROJECT;do
+	echo $RESULTS | jq -rc '.[]' | while IFS='' read PROJECT; do
 
 		NAME=$(echo $PROJECT | jq -rc '.name');
 		APPLICATION=$(echo $PROJECT | jq -rc '.labels.app');
 		OWNER=$(echo $PROJECT | jq -rc '.labels.adid');
-		
-		echo "$NAME ($APPLICATION): $OWNER";
+
+		if [[ $CSV == "True" ]]; then
+			echo "\"$NAME\",\"$APPLICATION\",\"$OWNER\"";
+		else
+			echo "$NAME ($APPLICATION): $OWNER";
+		fi;
 	done;
 else
 	echo "No projects found";

--- a/utility-list-project-owners.sh
+++ b/utility-list-project-owners.sh
@@ -6,54 +6,70 @@ declare RESULTS=$(gcloud projects list --format="json");
 
 declare DEBUG="False";
 declare CSV="False";
+declare OWNER_ONLY="False";
 declare HELP=$(cat << EOL
-	$0 [-c, --csv] [-d, --debug] [-h, --help]	
+	$0 [-c, --csv] [-d, --debug] [-h, --help] [-o, --owner-only]
 EOL
 );
 
 for arg in "$@"; do
   shift
   case "$arg" in
-    "--help") 	set -- "$@" "-h" ;;
-    "--debug") 	set -- "$@" "-d" ;;
-    "--csv") 	set -- "$@" "-c" ;;
-    *)        	set -- "$@" "$arg"
+    "--help")        set -- "$@" "-h" ;;
+    "--debug")       set -- "$@" "-d" ;;
+    "--csv")         set -- "$@" "-c" ;;
+    "--owner-only")  set -- "$@" "-o" ;;
+    *)               set -- "$@" "$arg"
   esac
 done
 
-while getopts "hdcp:" option
+while getopts "hdco" option
 do 
     case "${option}"
         in
         d)
-        	DEBUG="True";;
+            DEBUG="True";;
         c)
-        	CSV="True";;
+            CSV="True";;
+        o)
+            OWNER_ONLY="True";;
         h)
-        	echo $HELP; 
-        	exit 0;;
+            echo "$HELP"; 
+            exit 0;;
     esac;
 done;
 
 if [[ $RESULTS != "[]" ]]; then
-	if [[ $CSV == "True" ]]; then
-		echo "\"PROJECT_NAME\",\"PROJECT_APPLICATION\",\"PROJECT_OWNER\"";
-	fi
-		
-	echo $RESULTS | jq -rc '.[]' | while IFS='' read PROJECT; do
+    if [[ $CSV == "True" ]]; then
+        if [[ $OWNER_ONLY == "True" ]]; then
+            echo "\"PROJECT_OWNER\"";
+        else
+            echo "\"PROJECT_NAME\",\"PROJECT_APPLICATION\",\"PROJECT_OWNER\"";
+        fi
+    fi
+        
+    echo $RESULTS | jq -rc '.[]' | while IFS='' read PROJECT; do
+        PROJECT_NAME=$(echo $PROJECT | jq -rc '.name');
+        PROJECT_APPLICATION=$(echo $PROJECT | jq -rc '.labels.app');
+        PROJECT_OWNER=$(echo $PROJECT | jq -rc '.labels.adid');
 
-		NAME=$(echo $PROJECT | jq -rc '.name');
-		APPLICATION=$(echo $PROJECT | jq -rc '.labels.app');
-		OWNER=$(echo $PROJECT | jq -rc '.labels.adid');
-
-		if [[ $CSV == "True" ]]; then
-			echo "\"$NAME\",\"$APPLICATION\",\"$OWNER\"";
-		else
-			echo "$NAME ($APPLICATION): $OWNER";
-		fi;
-	done;
+        if [[ $CSV == "True" ]]; then
+            if [[ $OWNER_ONLY == "True" ]]; then
+                echo "\"$PROJECT_OWNER\"";
+            else
+                echo "\"$PROJECT_NAME\",\"$PROJECT_APPLICATION\",\"$PROJECT_OWNER\"";
+            fi
+        else
+            if [[ $OWNER_ONLY == "True" ]]; then
+                echo "$PROJECT_OWNER";
+            else
+                echo "$PROJECT_NAME ($PROJECT_APPLICATION): $PROJECT_OWNER";
+            fi
+        fi
+    done
 else
-	echo "No projects found";
-	echo "";
+    echo "No projects found";
+    echo "";
 fi;
+
 


### PR DESCRIPTION
files is working as expected, displaying the CSV output with the header PROJECT_NAME, PROJECT_APPLICATION, PROJECT_OWNER if -c is provided, help menu if -h is provided, and debug is -d.